### PR TITLE
Add remap dependencies for proper field remapping

### DIFF
--- a/plugin/src/main/kotlin/xyz/jpenilla/specialgradle/Constants.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/specialgradle/Constants.kt
@@ -20,6 +20,8 @@ public object Constants {
   public const val SPECIAL_SOURCE_CONFIGURATION_NAME: String = "specialSource"
   public const val MOJANG_TO_OBF_MAPPINGS_CONFIGURATION_NAME: String = "mojangToObfMappings"
   public const val OBF_TO_RUNTIME_MAPPINGS_CONFIGURATION_NAME: String = "obfToRuntimeMappings"
+  public const val REMAPPED_DEPENDENCIES_MOJANG_CONFIGURATION_NAME: String = "remappedMojang"
+  public const val REMAPPED_DEPENDENCIES_OBF_CONFIGURATION_NAME: String = "remappedObf"
 
   public const val SPECIAL_GRADLE_EXTENSION_NAME: String = "specialGradle"
 

--- a/plugin/src/main/kotlin/xyz/jpenilla/specialgradle/SpecialGradle.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/specialgradle/SpecialGradle.kt
@@ -34,6 +34,8 @@ public abstract class SpecialGradle : Plugin<Project> {
     }
     target.configurations.register(Constants.MOJANG_TO_OBF_MAPPINGS_CONFIGURATION_NAME)
     target.configurations.register(Constants.OBF_TO_RUNTIME_MAPPINGS_CONFIGURATION_NAME)
+    target.configurations.register(Constants.REMAPPED_DEPENDENCIES_MOJANG_CONFIGURATION_NAME)
+    target.configurations.register(Constants.REMAPPED_DEPENDENCIES_OBF_CONFIGURATION_NAME)
 
     val obf = target.tasks.register<RemapJar>(Constants.OBF_JAR_TASK_NAME) {
       this.reverse.set(true)
@@ -41,11 +43,17 @@ public abstract class SpecialGradle : Plugin<Project> {
       this.mappingsFile.set(this.project.layout.file(this.project.configurations.named(Constants.MOJANG_TO_OBF_MAPPINGS_CONFIGURATION_NAME).map {
         it.singleFile
       }))
+      this.remapDependency.set(this.project.layout.file(this.project.configurations.named(Constants.REMAPPED_DEPENDENCIES_MOJANG_CONFIGURATION_NAME).map {
+        it.singleFile
+      }))
     }
     target.tasks.register<RemapJar>(Constants.PRODUCTION_MAPPED_JAR_TASK_NAME) {
       this.inputJar.set(obf.flatMap { it.archiveFile })
       this.archiveClassifier.set(null as String?)
       this.mappingsFile.set(this.project.layout.file(this.project.configurations.named(Constants.OBF_TO_RUNTIME_MAPPINGS_CONFIGURATION_NAME).map {
+        it.singleFile
+      }))
+      this.remapDependency.set(this.project.layout.file(this.project.configurations.named(Constants.REMAPPED_DEPENDENCIES_OBF_CONFIGURATION_NAME).map {
         it.singleFile
       }))
     }

--- a/plugin/src/main/kotlin/xyz/jpenilla/specialgradle/task/RemapJar.kt
+++ b/plugin/src/main/kotlin/xyz/jpenilla/specialgradle/task/RemapJar.kt
@@ -32,6 +32,9 @@ public abstract class RemapJar : Jar() {
   @get:InputFile
   public abstract val mappingsFile: RegularFileProperty
 
+  @get:InputFile
+  public abstract val remapDependency: RegularFileProperty
+
   @get:Input
   public val reverse: Property<Boolean> = this.project.objects.property<Boolean>().convention(false)
 
@@ -43,16 +46,20 @@ public abstract class RemapJar : Jar() {
     dir.asFile.mkdirs()
     val inputJar = this@RemapJar.inputJar.get().asFile
     val mappingsFile = this@RemapJar.mappingsFile.get().asFile
+    val dependency = this@RemapJar.remapDependency.get().asFile
     val dest = dir.file("${inputJar.nameWithoutExtension}-mapped-${mappingsFile.nameWithoutExtension}.jar").asFile
     this.project.javaexec {
-      this.classpath(specialSourceJar)
+      this.main = "net.md_5.specialsource.SpecialSource"
+      this.classpath(specialSourceJar, dependency)
       this.args(
         "-i",
         inputJar.absolutePath,
         "-o",
         dest.absolutePath,
         "-m",
-        mappingsFile.absolutePath
+        mappingsFile.absolutePath,
+        "--live",
+        "--quiet"
       )
       if (this@RemapJar.reverse.get()) {
         this.args("--reverse")

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
   compileOnly(group = "org.spigotmc", name = "spigot", version = spigotVer, classifier = "remapped-mojang")
   // add mappings installed to maven local by build tools
   mojangToObfMappings(group = "org.spigotmc", name = "minecraft-server", version = spigotVer, ext = "txt", classifier = "maps-mojang")
+  remappedMojang(group = "org.spigotmc", name = "spigot", version = spigotVer, classifier = "remapped-mojang")
   obfToRuntimeMappings(group = "org.spigotmc", name = "minecraft-server", version = spigotVer, ext = "csrg", classifier = "maps-spigot")
+  remappedObf(group = "org.spigotmc", name = "spigot", version = spigotVer, classifier = "remapped-obf")
 }
 
 // set productionMappedJar to run on build


### PR DESCRIPTION
As the plugin currently is, it fails to remap the majority of fields due to inheritance issues. md_5 recently updated the manual commands required to run to get the fields remapping properly, and this PR applies those changes to this plugin.

This is related to #1 